### PR TITLE
enhancement/quick-deployment/TES-477

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,0 +1,15 @@
+# Build step
+FROM python:3.10 as requirements-stage
+WORKDIR /tmp
+RUN pip install poetry
+COPY ./pyproject.toml ./poetry.lock* /tmp/
+RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
+
+# Run step
+FROM python:3.10
+WORKDIR /code
+COPY --from=requirements-stage /tmp/requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY . /code/
+RUN pip install poetry && poetry install
+CMD ["poetry", "run", "start"]

--- a/ONTOTEXT.md
+++ b/ONTOTEXT.md
@@ -26,7 +26,7 @@ In the upstream version, when using Weaviate and issuing a delete all request, t
 the documents but also the corresponding schema. In the forked version we resolve this by recreating the schema
 automatically after a delete all operation.
 
-# Simple run
+# Simple deployment for testing
 
 In order to run this in a quick prepackaged environment, together with GraphDB, you can use the bundled
 `docker-compose.yml`. This will start GraphDB, Weaviate and the retrieval plugin on ports 7200, 8080 and 8000.

--- a/ONTOTEXT.md
+++ b/ONTOTEXT.md
@@ -25,3 +25,9 @@ export CHUNK_SIZE=1000
 In the upstream version, when using Weaviate and issuing a delete all request, the plugin will delete not only
 the documents but also the corresponding schema. In the forked version we resolve this by recreating the schema
 automatically after a delete all operation.
+
+# Simple run
+
+In order to run this in a quick prepackaged environment, together with GraphDB, you can use the bundled
+`docker-compose.yml`. This will start GraphDB, Weaviate and the retrieval plugin on ports 7200, 8080 and 8000.
+Remember to set your GPT key and the `BEARER_TOKEN` in the `docker-compose.yml`, as per our documentation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+---
+version: '3.4'
+services:
+  weaviate:
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    image: semitechnologies/weaviate:1.21.2
+    ports:
+    - 8080:8080
+    restart: on-failure
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      ENABLE_MODULES: ''
+      CLUSTER_HOSTNAME: 'node1'
+  retrieval:
+    build:
+      context: .
+      dockerfile: Dockerfile.run
+    ports:
+    - 8000:8000
+    restart: on-failure
+    environment:
+      OPENAI_API_KEY: SET YOUR OWN
+      DATASTORE: 'weaviate'
+      WEAVIATE_URL: 'http://weaviate:8080'
+      WEAVIATE_CLASS: 'STARWARS'
+      CHUNK_SIZE: '400'
+      BEARER_TOKEN: 'SET YOUR OWN'
+  graphdb:
+    image: ontotext/graphdb:10.5.1
+    restart: always
+    ports:
+      - "7200:7200"
+    environment:
+      GDB_JAVA_OPTS: >-
+        -Xmx2g -Xms2g
+        -Denable-context-index=true
+        -Dentity-pool-implementation=transactional
+        -Dhealth.max.query.time.seconds=60
+        -Dgraphdb.append.request.id.headers=true
+        -Dgraphdb.gpt.token=SET YOUR OWN
+        -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
+    volumes:
+      - graphdb_data:/opt/graphdb/home
+
+volumes:
+  weaviate_data:
+  graphdb_data:
+...


### PR DESCRIPTION
Closes TES-477

Simplifies test deployments for users without python or poetry. Now only a docker-compose up is necessary to run, coupled with setting the GPT keys.