### PR TITLE
enhancement/update-blogpost/MKTG-5064

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     image: semitechnologies/weaviate:1.21.2
     ports:
     - 8080:8080
+    volumes:
+    - weaviate_data:/var/lib/weaviate
     restart: on-failure
     environment:
       QUERY_DEFAULTS_LIMIT: 25
@@ -35,7 +37,7 @@ services:
       CHUNK_SIZE: '400'
       BEARER_TOKEN: 'SET YOUR OWN'
   graphdb:
-    image: ontotext/graphdb:10.5.1
+    image: ontotext/graphdb:10.6.2
     restart: always
     ports:
       - "7200:7200"
@@ -52,6 +54,6 @@ services:
       - graphdb_data:/opt/graphdb/home
 
 volumes:
-  weaviate_data:
   graphdb_data:
+  weaviate_data:
 ...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,11 +44,9 @@ services:
     environment:
       GDB_JAVA_OPTS: >-
         -Xmx2g -Xms2g
-        -Denable-context-index=true
-        -Dentity-pool-implementation=transactional
         -Dhealth.max.query.time.seconds=60
         -Dgraphdb.append.request.id.headers=true
-        -Dgraphdb.gpt.token=SET YOUR OWN
+        -Dgraphdb.gpt.token=SET_YOUR_OWN
         -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
     volumes:
       - graphdb_data:/opt/graphdb/home


### PR DESCRIPTION
Closes MKTG-5064.

Updates version of GraphDB in composition to simplify run for users following the blogpost mentioned. Also adds a weaviate volume to enable restarts of the composition.