### PR TITLE
[Documentation] Update documentation to reflect usage of poetry version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Follow these steps to quickly set up and run the ChatGPT Retrieval Plugin:
 1. Install Python 3.10, if not already installed.
 2. Clone the repository: `git clone https://github.com/openai/chatgpt-retrieval-plugin.git`
 3. Navigate to the cloned repository directory: `cd /path/to/chatgpt-retrieval-plugin`
-4. Install poetry: `pip install poetry`
+4. Install poetry: `pip install poetry==1.8.5`
 5. Create a new virtual environment with Python 3.10: `poetry env use python3.10`
 6. Activate the virtual environment: `poetry shell`
 7. Install app dependencies: `poetry install`


### PR DESCRIPTION
Update README to explicitly state the use of poetry version 1 (latest version 1 is 1.8.5). As of writing this poetry version 2 is out, and when running 'pip install poetry', version 2 is automatically installed. But, the project, as it is in the current state, is not properly working with version 2.